### PR TITLE
Remove () from u16().

### DIFF
--- a/src/gzip.rs
+++ b/src/gzip.rs
@@ -449,7 +449,7 @@ impl ExtraField {
         where W: io::Write
     {
         writer.write_all(&self.id)?;
-        writer.write_u16::<LittleEndian>(self.data.len() as u16())?;
+        writer.write_u16::<LittleEndian>(self.data.len() as u16)?;
         writer.write_all(&self.data)?;
         Ok(())
     }


### PR DESCRIPTION
Parentheses after primitive types will be prohibited in the future by rust-lang/rust#42238. This patch will remove the parentheses.