### PR TITLE
fix #6: read the XLEN extra field len

### DIFF
--- a/src/gzip.rs
+++ b/src/gzip.rs
@@ -437,10 +437,14 @@ impl ExtraField {
             id: [0; 2],
             data: Vec::new(),
         };
+        let data_size = reader.read_u16::<LittleEndian>()? as usize;
+        if data_size < 2 {
+            return Err(invalid_data_error!("extra field is too short: {}", data_size));
+        }
+
         reader.read_exact(&mut extra.id)?;
 
-        let data_size = reader.read_u16::<LittleEndian>()? as usize;
-        extra.data.resize(data_size, 0);
+        extra.data.resize(data_size - 2, 0);
         reader.read_exact(&mut extra.data)?;
 
         Ok(extra)


### PR DESCRIPTION
Previously, the code was assuming that layout was [id] [len], whereas it is [len] [id] [len again] (in most cases?). The spec definitely agrees, although is super easy to misread.

See 2.3 "member format": https://tools.ietf.org/html/rfc1952#page-5

The XLEN comes before the extra field. "2.3.1.1. Extra field" goes on to explain that the len is repeated.