### PR TITLE
Add `as_inner_{ref,mut}` and `into_inner` methods to every `Encoder` and `Decoder`

### DIFF
--- a/src/gzip.rs
+++ b/src/gzip.rs
@@ -807,6 +807,21 @@ where
             Err(e) => Finish::new(inner, Some(e)),
         }
     }
+
+    /// Returns the immutable reference to the inner stream.
+    pub fn as_inner_ref(&self) -> &W {
+        self.writer.as_inner_ref()
+    }
+
+    /// Returns the mutable reference to the inner stream.
+    pub fn as_inner_mut(&mut self) -> &mut W {
+        self.writer.as_inner_mut()
+    }
+
+    /// Unwraps the `Encoder`, returning the inner stream.
+    pub fn into_inner(self) -> W {
+        self.writer.into_inner()
+    }
 }
 impl<W, E> io::Write for Encoder<W, E>
 where
@@ -884,6 +899,16 @@ where
     /// ```
     pub fn header(&self) -> &Header {
         &self.header
+    }
+
+    /// Returns the immutable reference to the inner stream.
+    pub fn as_inner_ref(&self) -> &R {
+        self.reader.as_inner_ref()
+    }
+
+    /// Returns the mutable reference to the inner stream.
+    pub fn as_inner_mut(&mut self) -> &mut R {
+        self.reader.as_inner_mut()
     }
 
     /// Unwraps this `Decoder`, returning the underlying reader.
@@ -1000,6 +1025,22 @@ where
     /// ```
     pub fn header(&self) -> &Header {
         &self.header
+    }
+
+    /// Returns the immutable reference to the inner stream.
+    pub fn as_inner_ref(&self) -> &R {
+        match self.decoder {
+            Err(ref reader) => reader,
+            Ok(ref decoder) => decoder.as_inner_ref(),
+        }
+    }
+
+    /// Returns the mutable reference to the inner stream.
+    pub fn as_inner_mut(&mut self) -> &mut R {
+        match self.decoder {
+            Err(ref mut reader) => reader,
+            Ok(ref mut decoder) => decoder.as_inner_mut(),
+        }
     }
 
     /// Unwraps this `MultiDecoder`, returning the underlying reader.

--- a/src/non_blocking/gzip.rs
+++ b/src/non_blocking/gzip.rs
@@ -89,6 +89,16 @@ impl<R: Read> Decoder<R> {
         }
     }
 
+    /// Returns the immutable reference to the inner stream.
+    pub fn as_inner_ref(&self) -> &R {
+        self.reader.as_inner_ref()
+    }
+
+    /// Returns the mutable reference to the inner stream.
+    pub fn as_inner_mut(&mut self) -> &mut R {
+        self.reader.as_inner_mut()
+    }
+
     /// Unwraps this `Decoder`, returning the underlying reader.
     ///
     /// # Examples

--- a/src/non_blocking/zlib.rs
+++ b/src/non_blocking/zlib.rs
@@ -90,6 +90,16 @@ impl<R: Read> Decoder<R> {
         }
     }
 
+    /// Returns the immutable reference to the inner stream.
+    pub fn as_inner_ref(&self) -> &R {
+        self.reader.as_inner_ref()
+    }
+
+    /// Returns the mutable reference to the inner stream.
+    pub fn as_inner_mut(&mut self) -> &mut R {
+        self.reader.as_inner_mut()
+    }
+
     /// Unwraps this `Decoder`, returning the underlying reader.
     ///
     /// # Examples

--- a/src/zlib.rs
+++ b/src/zlib.rs
@@ -316,6 +316,16 @@ where
         &self.header
     }
 
+    /// Returns the immutable reference to the inner stream.
+    pub fn as_inner_ref(&self) -> &R {
+        self.reader.as_inner_ref()
+    }
+
+    /// Returns the mutable reference to the inner stream.
+    pub fn as_inner_mut(&mut self) -> &mut R {
+        self.reader.as_inner_mut()
+    }
+
     /// Unwraps this `Decoder`, returning the underlying reader.
     ///
     /// # Examples
@@ -575,6 +585,21 @@ where
             Ok(_) => Finish::new(inner, None),
             Err(e) => Finish::new(inner, Some(e)),
         }
+    }
+
+    /// Returns the immutable reference to the inner stream.
+    pub fn as_inner_ref(&self) -> &W {
+        self.writer.as_inner_ref()
+    }
+
+    /// Returns the mutable reference to the inner stream.
+    pub fn as_inner_mut(&mut self) -> &mut W {
+        self.writer.as_inner_mut()
+    }
+
+    /// Unwraps the `Encoder`, returning the inner stream.
+    pub fn into_inner(self) -> W {
+        self.writer.into_inner()
     }
 }
 impl<W, E> io::Write for Encoder<W, E>


### PR DESCRIPTION
As the title suggests.