### PR TITLE
use crc32fast crate for simd-accelerated checksum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ codecov = {repository = "sile/libflate"}
 [dependencies]
 adler32 = "1"
 byteorder = "1"
-crc = "1"
+crc32fast = "1"
 
 [dev-dependencies]
 clap = "2"

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -1,5 +1,5 @@
 use adler32::RollingAdler32;
-use crc::{crc32, Hasher32};
+use crc32fast;
 use std::fmt;
 
 pub struct Adler32(RollingAdler32);
@@ -20,16 +20,16 @@ impl fmt::Debug for Adler32 {
     }
 }
 
-pub struct Crc32(crc32::Digest);
+pub struct Crc32(crc32fast::Hasher);
 impl Crc32 {
     pub fn new() -> Self {
-        Crc32(crc32::Digest::new(crc32::IEEE))
+        Crc32(crc32fast::Hasher::new())
     }
     pub fn value(&self) -> u32 {
-        self.0.sum32()
+        self.0.clone().finalize()
     }
     pub fn update(&mut self, buf: &[u8]) {
-        self.0.write(buf);
+        self.0.update(buf);
     }
 }
 impl fmt::Debug for Crc32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(inline_always))]
 extern crate adler32;
 extern crate byteorder;
-extern crate crc;
+extern crate crc32fast;
 
 pub use finish::Finish;
 


### PR DESCRIPTION
The [`crc32fast`](https://crates.io/crates/crc32fast) crate is a result from the performance work I've been doing on the `zip` crate. Compared to the `crc` crate, it speeds up throughput between 7x and 35x, depending on whether the target machine supports SIMD.