### PR TITLE
Drop unsafe code from currently unsound function prefix()

### DIFF
--- a/src/lz77/default.rs
+++ b/src/lz77/default.rs
@@ -109,14 +109,9 @@ impl Lz77Encode for DefaultLz77Encoder {
 }
 
 #[inline]
-fn prefix(buf: &[u8]) -> [u8; 3] {
-    unsafe {
-        [
-            *buf.get_unchecked(0),
-            *buf.get_unchecked(1),
-            *buf.get_unchecked(2),
-        ]
-    }
+fn prefix(input_buf: &[u8]) -> [u8; 3] {
+    let buf: &[u8] = &input_buf[..3]; // perform bounds check once
+    [buf[0], buf[1], buf[2]]
 }
 
 #[inline]


### PR DESCRIPTION
Fixes #29

This changes the generated assembly from

```asm
 movzx   ecx, byte, ptr, [rdi]
 movzx   eax, byte, ptr, [rdi, +, 1]
 movzx   edx, byte, ptr, [rdi, +, 2]
 shl     edx, 16
 shl     eax, 8
 or      eax, ecx
 or      eax, edx
 ret
```

to
```asm
 push    rax
 cmp     rsi, 2
 jbe     .LBB106_1
 movzx   ecx, byte, ptr, [rdi]
 movzx   eax, byte, ptr, [rdi, +, 1]
 movzx   edx, byte, ptr, [rdi, +, 2]
 shl     edx, 16
 shl     eax, 8
 or      eax, ecx
 or      eax, edx
 pop     rcx
 ret
.LBB106_1:
 mov     edi, 3
 call    qword, ptr, [rip, +, _ZN4core5slice20slice_index_len_fail17hbeb3bb6238e26ddbE@GOTPCREL]
 ud2
```
which is as good as it's going to get without restructuring the code.

This change incurs at about 1% performance penalty. This was tested without inlining, which may elide bounds checks further. Performance penalty can probably be avoided altogether by using `slice::windows()` plus [one of the ways to skip iterator elements](https://users.rust-lang.org/t/how-to-skip-forward-in-iterator-without-moving-it/3003) in function `flush()` instead of indexing, but I'm not sure it's worth the trouble.