### PR TITLE
Drop unsafe code from truncate_old_buffer() 

### DIFF
--- a/src/deflate/decode.rs
+++ b/src/deflate/decode.rs
@@ -3,7 +3,6 @@ use byteorder::ReadBytesExt;
 use std::cmp;
 use std::io;
 use std::io::Read;
-use std::ptr;
 
 use super::symbol;
 use bit;

--- a/src/deflate/decode.rs
+++ b/src/deflate/decode.rs
@@ -135,11 +135,11 @@ where
     }
     fn truncate_old_buffer(&mut self) {
         if self.buffer.len() > lz77::MAX_DISTANCE as usize * 4 {
+            let old_len = self.buffer.len();
             let new_len = lz77::MAX_DISTANCE as usize;
-            unsafe {
-                let ptr = self.buffer.as_mut_ptr();
-                let src = ptr.add(self.buffer.len() - new_len);
-                ptr::copy_nonoverlapping(src, ptr, new_len);
+            { // isolation to please borrow checker
+                let (dst, src) = self.buffer.split_at_mut(old_len - new_len);
+                dst[..new_len].copy_from_slice(src);
             }
             self.buffer.truncate(new_len);
             self.offset = new_len;

--- a/src/non_blocking/deflate/decode.rs
+++ b/src/non_blocking/deflate/decode.rs
@@ -235,11 +235,11 @@ impl BlockDecoder {
     }
     fn truncate_old_buffer(&mut self) {
         if self.buffer.len() > lz77::MAX_DISTANCE as usize * 4 {
+            let old_len = self.buffer.len();
             let new_len = lz77::MAX_DISTANCE as usize;
-            unsafe {
-                let ptr = self.buffer.as_mut_ptr();
-                let src = ptr.add(self.buffer.len() - new_len);
-                ptr::copy_nonoverlapping(src, ptr, new_len);
+            { // isolation to please borrow checker
+                let (dst, src) = self.buffer.split_at_mut(old_len - new_len);
+                dst[..new_len].copy_from_slice(src);
             }
             self.buffer.truncate(new_len);
             self.offset = new_len;

--- a/src/non_blocking/deflate/decode.rs
+++ b/src/non_blocking/deflate/decode.rs
@@ -3,7 +3,6 @@ use byteorder::ReadBytesExt;
 use std::cmp;
 use std::io;
 use std::io::Read;
-use std::ptr;
 
 use deflate::symbol::{self, HuffmanCodec};
 use lz77;


### PR DESCRIPTION
This has no measurable performance difference. flate-bench was too noisy, so I've used hyperfine to measure it:

`hyperfine --min-runs=25 --warmup=3 'target/release/examples/flate -i enwiki-latest-all-titles-in-ns0.gz -o /dev/null gzip-decode'`

This also does not regress rustc version compatibility because ptr::add has been added in 1.26 while slice::split_at_mut has been around since 1.0 and slice::copy_from_slice since 1.9