### PR TITLE
Address part of #31

### DIFF
--- a/src/deflate/decode.rs
+++ b/src/deflate/decode.rs
@@ -83,8 +83,11 @@ where
             ))
         } else {
             let old_len = self.buffer.len();
-            self.buffer.reserve(len as usize);
-            unsafe { self.buffer.set_len(old_len + len as usize) };
+            // We cannot use `self.buffer.set_len()` here because that would
+            // pass uninitialized memory to .read_exact(), which does
+            // NOT guarantee that it will never read from the buffer.
+            // See https://github.com/rust-lang/rust/pull/62102/
+            self.buffer.resize(old_len + len as usize, 0);
             self.bit_reader
                 .as_inner_mut()
                 .read_exact(&mut self.buffer[old_len..])?;

--- a/src/deflate/decode.rs
+++ b/src/deflate/decode.rs
@@ -87,6 +87,8 @@ where
             // pass uninitialized memory to .read_exact(), which does
             // NOT guarantee that it will never read from the buffer.
             // See https://github.com/rust-lang/rust/pull/62102/
+            // Surprisingly, zero-initializing the buffer here
+            // makes decoding 5% **faster** than using reserve() + set_len()
             self.buffer.resize(old_len + len as usize, 0);
             self.bit_reader
                 .as_inner_mut()


### PR DESCRIPTION
Fixes one occurrence of unsoundness described in #31 

This change actually makes decoding 5% **faster** - as measured with hyperfine:

`hyperfine -m 25 --warmup=3 'target/release/examples/flate -i enwiki-latest-all-titles-in-ns0.gz -o /dev/null gzip-decode'`

On my machine the time goes down from 2.250s to 2.150s

Tests still pass.