### PR TITLE
Use lookup tables safely

### DIFF
--- a/src/deflate/symbol.rs
+++ b/src/deflate/symbol.rs
@@ -212,7 +212,7 @@ impl Decoder {
             }
             length_code => {
                 let (base, extra_bits) =
-                    unsafe { *LENGTH_TABLE.get_unchecked(length_code as usize - 257) };
+                    LENGTH_TABLE[length_code as usize - 257];
                 let extra = reader.read_bits_unchecked(extra_bits);
                 Symbol::Share {
                     length: base + extra,
@@ -227,7 +227,7 @@ impl Decoder {
         R: io::Read,
     {
         let decoded = self.distance.decode_unchecked(reader) as usize;
-        let (base, extra_bits) = unsafe { *DISTANCE_TABLE.get_unchecked(decoded) };
+        let (base, extra_bits) = DISTANCE_TABLE[decoded];
         let extra = reader.read_bits_unchecked(extra_bits);
         base + extra
     }

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -99,9 +99,7 @@ impl Builder for DecoderBuilder {
                 );
                 return Err(io::Error::new(io::ErrorKind::InvalidData, message));
             }
-            unsafe {
-                *self.table.get_unchecked_mut(i) = value;
-            }
+            self.table[i] = value;
         }
         Ok(())
     }
@@ -137,11 +135,11 @@ impl Decoder {
         R: io::Read,
     {
         let code = reader.peek_bits_unchecked(self.eob_bitwidth);
-        let mut value = unsafe { *self.table.get_unchecked(code as usize) };
+        let mut value = self.table[code as usize];
         let mut bitwidth = (value & 0b1_1111) as u8;
         if bitwidth > self.eob_bitwidth {
             let code = reader.peek_bits_unchecked(self.max_bitwidth);
-            value = unsafe { *self.table.get_unchecked(code as usize) };
+            value = self.table[code as usize];
             bitwidth = (value & 0b1_1111) as u8;
             if bitwidth > self.max_bitwidth {
                 reader.set_last_error(invalid_data_error!("Invalid huffman coded stream"));
@@ -216,7 +214,7 @@ impl Encoder {
             symbol,
             self.table.len()
         );
-        unsafe { self.table.get_unchecked(symbol as usize) }.clone()
+        self.table[symbol as usize].clone()
     }
     pub fn used_max_symbol(&self) -> Option<u16> {
         self.table

--- a/src/lz77/default.rs
+++ b/src/lz77/default.rs
@@ -165,7 +165,7 @@ impl LargePrefixTable {
         let p2 = prefix[2];
 
         let i = (p0 << 8) + p1;
-        let positions = unsafe { self.table.get_unchecked_mut(i) };
+        let positions = &mut self.table[i];
         for &mut (key, ref mut value) in positions.iter_mut() {
             if key == p2 {
                 let old = *value;


### PR DESCRIPTION
Use regular indexing operations for lookup tables instead of `get_unchecked()`. This regresses performance by 0.7% - decoding enwiki-latest-all-titles-in-ns0.gz goes from 2,160s to 2,175s on my machine, as measured with hyperfine:
`hyperfine -m 25 --warmup=3 'target/release/examples/flate -i enwiki-latest-all-titles-in-ns0.gz -o /dev/null gzip-decode'`

Since the main selling point of a Rust implementation is safety, I don't think using `unsafe` for less than 1% speedup is justified.