### PR TITLE
Use take_mut instead of a bespoke unsafe block with mem::replace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ codecov = {repository = "sile/libflate"}
 adler32 = "1"
 byteorder = "1"
 crc32fast = "1"
+take_mut = "0.2.2"
 
 [dev-dependencies]
 clap = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate adler32;
 extern crate byteorder;
 extern crate crc32fast;
+extern crate take_mut;
 
 pub use finish::Finish;
 


### PR DESCRIPTION
`mem::uninitialized` is getting deprecated because [it's impossible to use it safely in generic code](https://gankro.github.io/blah/initialize-me-maybe/).

On the other hand, `take_mut` has been reviewed by the Unsafe Code Guidelines WG and has been found to be sound.