### PR TITLE
Switch to rle_decode_fast crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ codecov = {repository = "sile/libflate"}
 adler32 = "1"
 byteorder = "1"
 crc32fast = "1"
+rle-decode-helper = {git = "https://github.com/Shnatsel/rle-decode-helper.git"}
 
 [dev-dependencies]
 clap = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ codecov = {repository = "sile/libflate"}
 adler32 = "1"
 byteorder = "1"
 crc32fast = "1"
-rle-decode-helper = {git = "https://github.com/Shnatsel/rle-decode-helper.git"}
+rle-decode-fast = {git = "https://github.com/Shnatsel/rle-decode-helper.git"}
 take_mut = "0.2.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ codecov = {repository = "sile/libflate"}
 adler32 = "1"
 byteorder = "1"
 crc32fast = "1"
-rle-decode-fast = {git = "https://github.com/Shnatsel/rle-decode-helper.git"}
+rle-decode-fast = "1.0.0"
 take_mut = "0.2.2"
 
 [dev-dependencies]

--- a/src/deflate/decode.rs
+++ b/src/deflate/decode.rs
@@ -3,6 +3,7 @@ use byteorder::ReadBytesExt;
 use std::cmp;
 use std::io;
 use std::io::Read;
+use rle_decode_helper::rle_decode;
 
 use super::symbol;
 use bit;
@@ -116,19 +117,7 @@ where
                             distance
                         ));
                     }
-                    let old_len = self.buffer.len();
-                    self.buffer.reserve(length as usize);
-                    unsafe {
-                        self.buffer.set_len(old_len + length as usize);
-                        let start = old_len - distance as usize;
-                        let ptr = self.buffer.as_mut_ptr();
-                        util::ptr_copy(
-                            ptr.add(start),
-                            ptr.add(old_len),
-                            length as usize,
-                            length > distance,
-                        );
-                    }
+                    rle_decode(&mut self.buffer, usize::from(distance), usize::from(length));
                 }
                 symbol::Symbol::EndOfBlock => {
                     break;

--- a/src/deflate/decode.rs
+++ b/src/deflate/decode.rs
@@ -3,7 +3,7 @@ use byteorder::ReadBytesExt;
 use std::cmp;
 use std::io;
 use std::io::Read;
-use rle_decode_helper::rle_decode;
+use rle_decode_fast::rle_decode;
 
 use super::symbol;
 use bit;

--- a/src/deflate/decode.rs
+++ b/src/deflate/decode.rs
@@ -8,7 +8,6 @@ use rle_decode_fast::rle_decode;
 use super::symbol;
 use bit;
 use lz77;
-use util;
 
 /// DEFLATE decoder.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate adler32;
 extern crate byteorder;
 extern crate crc32fast;
+extern crate rle_decode_helper;
 
 pub use finish::Finish;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 extern crate adler32;
 extern crate byteorder;
 extern crate crc32fast;
-extern crate rle_decode_helper;
+extern crate rle_decode_fast;
 extern crate take_mut;
 
 pub use finish::Finish;

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,17 +2,6 @@
 use std::io::{self, Read};
 use std::ptr;
 
-#[inline]
-pub unsafe fn ptr_copy(src: *const u8, dst: *mut u8, count: usize, is_overlapping: bool) {
-    if !is_overlapping {
-        ptr::copy_nonoverlapping(src, dst, count);
-    } else {
-        for i in 0..count {
-            ptr::copy_nonoverlapping(src.add(i), dst.add(i), 1);
-        }
-    }
-}
-
 #[cfg(test)]
 pub struct WouldBlockReader<R> {
     inner: R,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 use std::io::{self, Read};
-use std::ptr;
 
 #[cfg(test)]
 pub struct WouldBlockReader<R> {


### PR DESCRIPTION
Use `rle_decode_fast` crate created by @WanzenBug and me instead of a bespoke unsafe block relying on non-local invariants.

This change improves performance by about 10% as measured with `hyperfine -m 25 --warmup=3 'target/release/examples/flate -i enwiki-latest-all-titles-in-ns0.gz -o /dev/null gzip-decode'`

Before:
```
  Time (mean ± σ):      2.295 s ±  0.016 s    [User: 2.275 s, System: 0.013 s]
  Range (min … max):    2.268 s …  2.320 s    25 runs
```

After:
```
  Time (mean ± σ):      2.079 s ±  0.022 s    [User: 2.069 s, System: 0.010 s]
  Range (min … max):    2.046 s …  2.132 s    25 runs
```


We're created the crate to solve recurring safety problems in RLE decoding. It contains a single unsafe block, which is a copy of `append_from_within()` function from [this Rust RFC](https://github.com/rust-lang/rfcs/pull/2714). We're reasonably confident it is sound because it's mostly a copy of a pre-exisitng stdlib function, and I cannot find anything wrong with its logic.