### PR TITLE
Remove byteorder-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ codecov = {repository = "sile/libflate"}
 
 [dependencies]
 adler32 = "1"
-byteorder = "1"
 crc32fast = "1"
 rle-decode-fast = "1.0.0"
 take_mut = "0.2.2"

--- a/src/deflate/decode.rs
+++ b/src/deflate/decode.rs
@@ -1,5 +1,3 @@
-use byteorder::LittleEndian;
-use byteorder::ReadBytesExt;
 use rle_decode_fast::rle_decode;
 use std::cmp;
 use std::io;
@@ -73,8 +71,11 @@ where
 
     fn read_non_compressed_block(&mut self) -> io::Result<()> {
         self.bit_reader.reset();
-        let len = self.bit_reader.as_inner_mut().read_u16::<LittleEndian>()?;
-        let nlen = self.bit_reader.as_inner_mut().read_u16::<LittleEndian>()?;
+        let mut buf = [0; 2];
+        self.bit_reader.as_inner_mut().read_exact(&mut buf)?;
+        let len = u16::from_le_bytes(buf);
+        self.bit_reader.as_inner_mut().read_exact(&mut buf)?;
+        let nlen = u16::from_le_bytes(buf);
         if !len != nlen {
             Err(invalid_data_error!(
                 "LEN={} is not the one's complement of NLEN={}",

--- a/src/deflate/encode.rs
+++ b/src/deflate/encode.rs
@@ -1,5 +1,3 @@
-use byteorder::LittleEndian;
-use byteorder::WriteBytesExt;
 use std::cmp;
 use std::io;
 
@@ -357,10 +355,10 @@ impl RawBuf {
         writer.flush()?;
         writer
             .as_inner_mut()
-            .write_u16::<LittleEndian>(size as u16)?;
+            .write_all(&(size as u16).to_le_bytes())?;
         writer
             .as_inner_mut()
-            .write_u16::<LittleEndian>(!size as u16)?;
+            .write_all(&(!size as u16).to_le_bytes())?;
         writer.as_inner_mut().write_all(&self.buf[..size])?;
         self.buf.drain(0..size);
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 //! A Rust implementation of DEFLATE algorithm and related formats (ZLIB, GZIP).
 #![warn(missing_docs)]
 extern crate adler32;
-extern crate byteorder;
 extern crate crc32fast;
 extern crate rle_decode_fast;
 extern crate take_mut;


### PR DESCRIPTION
This removes this `byteorder`-dependency which is not strictly needed since Rust 1.32. Due to a single use of `TryInto` (which could be avoided) the minimum Rust version is now 1.34.2

As one can see, there is a lot more manual reading/writing involved. I think the change is worth losing a dependency, though.

Fixes #40 