### PR TITLE
Make max share length in lz77 configurable

### DIFF
--- a/libflate_lz77/src/default.rs
+++ b/libflate_lz77/src/default.rs
@@ -9,8 +9,10 @@ use super::Sink;
 #[derive(Debug)]
 pub struct DefaultLz77Encoder {
     window_size: u16,
+    max_length: u16,
     buf: Vec<u8>,
 }
+
 impl DefaultLz77Encoder {
     /// Makes a new encoder instance.
     ///
@@ -26,7 +28,7 @@ impl DefaultLz77Encoder {
     /// let _deflate = deflate::Encoder::with_options(Vec::new(), options);
     /// ```
     pub fn new() -> Self {
-        Self::with_window_size(super::MAX_WINDOW_SIZE)
+        DefaultLz77EncoderBuilder::new().build()
     }
 
     /// Makes a new encoder instance with specified window size.
@@ -46,17 +48,18 @@ impl DefaultLz77Encoder {
     /// let _deflate = deflate::Encoder::with_options(Vec::new(), options);
     /// ```
     pub fn with_window_size(size: u16) -> Self {
-        DefaultLz77Encoder {
-            window_size: cmp::min(size, super::MAX_WINDOW_SIZE),
-            buf: Vec::new(),
-        }
+        DefaultLz77EncoderBuilder::new()
+            .window_size(cmp::min(size, super::MAX_WINDOW_SIZE))
+            .build()
     }
 }
+
 impl Default for DefaultLz77Encoder {
     fn default() -> Self {
         Self::new()
     }
 }
+
 impl Lz77Encode for DefaultLz77Encoder {
     fn encode<S>(&mut self, buf: &[u8], sink: S)
     where
@@ -80,7 +83,12 @@ impl Lz77Encode for DefaultLz77Encoder {
             if let Some(j) = matched.map(|j| j as usize) {
                 let distance = i - j;
                 if distance <= self.window_size as usize {
-                    let length = 3 + longest_common_prefix(&self.buf, i + 3, j + 3);
+                    let length = 3 + longest_common_prefix(
+                        &self.buf,
+                        i + 3,
+                        j + 3,
+                        self.max_length as usize,
+                    );
                     sink.consume(Code::Pointer {
                         length,
                         backward_distance: distance as u16,
@@ -115,10 +123,10 @@ fn prefix(input_buf: &[u8]) -> [u8; 3] {
 }
 
 #[inline]
-fn longest_common_prefix(buf: &[u8], i: usize, j: usize) -> u16 {
+fn longest_common_prefix(buf: &[u8], i: usize, j: usize, max: usize) -> u16 {
     buf[i..]
         .iter()
-        .take(super::MAX_LENGTH as usize - 3)
+        .take(max - 3)
         .zip(&buf[j..])
         .take_while(|&(x, y)| x == y)
         .count() as u16
@@ -175,5 +183,77 @@ impl LargePrefixTable {
         }
         positions.push((p2, position));
         None
+    }
+}
+
+/// Type for constructing instances of `DefaultLz77Encoder`.
+///
+/// # Examples
+/// ```
+/// use libflate_lz77::{
+///     DefaultLz77EncoderBuilder,
+///     MAX_LENGTH,
+///     MAX_WINDOW_SIZE,
+/// };
+///
+/// // Produce an encoder explicitly with the default window size and max copy length
+/// let _encoder = DefaultLz77EncoderBuilder::new()
+///     .window_size(MAX_WINDOW_SIZE)
+///     .max_length(MAX_LENGTH)
+///     .build();
+/// ```
+#[derive(Debug)]
+pub struct DefaultLz77EncoderBuilder {
+    window_size: u16,
+    max_length: u16,
+}
+
+impl DefaultLz77EncoderBuilder {
+    /// Create a builder with the default parameters for the encoder.
+    pub fn new() -> Self {
+        DefaultLz77EncoderBuilder {
+            window_size: super::MAX_WINDOW_SIZE,
+            max_length: super::MAX_LENGTH,
+        }
+    }
+
+    /// Set the size of the sliding search window used during compression.
+    ///
+    /// Larger values require more memory. The standard window size may be
+    /// unsuitable for a particular Sink; for example, if the encoding used
+    /// cannot express pointer distances past a certain size, you would want the
+    /// window size to be no greater than the Sink's limit.
+    pub fn window_size(self, window_size: u16) -> Self {
+        DefaultLz77EncoderBuilder {
+            window_size: cmp::min(window_size, super::MAX_WINDOW_SIZE),
+            ..self
+        }
+    }
+
+    /// Set the maximum length of a pointer command this encoder will emit.
+    ///
+    /// Some uses of LZ77 may not be able to encode pointers of the standard
+    /// maximum length of 258 bytes. In this case, you may set your own maximum
+    /// which can be encoded by the Sink.
+    pub fn max_length(self, max_length: u16) -> Self {
+        DefaultLz77EncoderBuilder {
+            max_length: cmp::min(max_length, super::MAX_LENGTH),
+            ..self
+        }
+    }
+
+    /// Build the encoder with the builder state's parameters.
+    pub fn build(self) -> DefaultLz77Encoder {
+        DefaultLz77Encoder {
+            window_size: self.window_size,
+            max_length: self.max_length,
+            buf: Vec::new(),
+        }
+    }
+}
+
+impl Default for DefaultLz77EncoderBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/libflate_lz77/src/lib.rs
+++ b/libflate_lz77/src/lib.rs
@@ -1,7 +1,7 @@
 //! The interface and implementations of LZ77 compression algorithm.
 //!
 //! LZ77 is a compression algorithm used in [DEFLATE](https://tools.ietf.org/html/rfc1951).
-pub use self::default::DefaultLz77Encoder;
+pub use self::default::{DefaultLz77Encoder, DefaultLz77EncoderBuilder};
 
 mod default;
 


### PR DESCRIPTION
Certain [erroneous implementations](https://segaretro.org/PRS_compression) of LZ77 have encodings that can't encode pointer shares of the standard maximum copy length of 258. In the linked example's case, for older iterations it can only copy up to 256 bytes in a single command. I figure that this may have been a performance optimization back in the 1990s, since newer games using this particular encoding have been fixed (though they still only support a window size of 8k).

This PR adds a Builder type to configure both the `MAX_LENGTH` constant _and_ the already-configurable window size in the default compressor implementation, and changes existing constructor paths to use that builder. It is backwards-compatible with existing code. There may be a slight performance loss as a result under all paths, but nothing significant.