### PR TITLE
Bump minimal version of `crc32fast` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ codecov = {repository = "sile/libflate"}
 
 [dependencies]
 adler32 = "1"
-crc32fast = "1"
+crc32fast = "1.1.1"
 libflate_lz77 = { path = "libflate_lz77", version = "1" }
 rle-decode-fast = "1.0.0"
 


### PR DESCRIPTION
Old versions of `crc32fast` doesn't compile on rustc-1.43.1.
The problem is fixed by <https://github.com/srijs/rust-crc32fast/commit/748869d592db7948a9b5c9b03eb784f18dfb2adb>, which is included since crc32fast 1.1.1.

You can reproduce the problem as following:

```
$ rustc --version
rustc 1.43.1 (8d69840ab 2020-05-04)
$ cargo +nightly update -Z minimal-versions
    Updating crates.io index
    Updating adler32 v1.0.4 -> v1.0.0
    Updating ansi_term v0.11.0 -> v0.7.0
    Removing atty v0.2.14
    Updating bitflags v1.2.1 -> v0.4.0
    Removing cfg-if v0.1.10
    Updating clap v2.33.1 -> v2.0.0
    Updating crc32fast v1.2.0 -> v1.0.1
    Removing hermit-abi v0.1.13
    Removing libc v0.2.71
    Updating rle-decode-fast v1.0.1 -> v1.0.0
      Adding rustc_version v0.2.0
      Adding semver v0.6.0
      Adding semver-parser v0.7.0
    Updating strsim v0.8.0 -> v0.4.0
    Removing textwrap v0.11.0
    Removing unicode-width v0.1.7
    Updating vec_map v0.8.2 -> v0.4.0
    Removing winapi v0.3.8
    Removing winapi-i686-pc-windows-gnu v0.4.0
    Removing winapi-x86_64-pc-windows-gnu v0.4.0
$ cargo check
   Compiling semver-parser v0.7.0
   Compiling semver v0.6.0
   Compiling rustc_version v0.2.0
   Compiling crc32fast v1.0.1
error[E0277]: the trait bound `rustc_version::Version: std::convert::From<({integer}, {integer}, {integer})>` is not satisfied
 --> /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/crc32fast-1.0.1/build.rs:8:30
  |
8 |     if version >= (1, 27, 0).into() {
  |                              ^^^^ the trait `std::convert::From<({integer}, {integer}, {integer})>` is not implemented for `rustc_version::Ver
sion`
  |
  = help: the following implementations were found:
            <rustc_version::Version as std::convert::From<semver_parser::version::Version>>
  = note: required because of the requirements on the impl of `std::convert::Into<rustc_version::Version>` for `({integer}, {integer}, {integer})`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
error: could not compile `crc32fast`.

To learn more, run the command again with --verbose.
$
```