### PR TITLE
lib: add support for no_std builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,11 @@ coveralls = {repository = "sile/libflate"}
 [dependencies]
 adler32 = "1"
 crc32fast = "1.1.1"
-libflate_lz77 = { path = "libflate_lz77", version = "1.1" }
+libflate_lz77 = { path = "libflate_lz77", version = "1.1", default_features = false }
+core2 = { version = "0.4", default_features = false, features = ["alloc"], optional = true }
+
+[features]
+no_std = ["libflate_lz77/no_std", "core2"]
 
 [dev-dependencies]
 clap = "2"

--- a/examples/flate.rs
+++ b/examples/flate.rs
@@ -1,17 +1,31 @@
 extern crate clap;
 extern crate libflate;
 
+#[cfg(not(feature = "no_std"))]
 use clap::App;
+#[cfg(not(feature = "no_std"))]
 use clap::Arg;
+#[cfg(not(feature = "no_std"))]
 use clap::SubCommand;
+#[cfg(not(feature = "no_std"))]
 use libflate::gzip;
+#[cfg(not(feature = "no_std"))]
 use libflate::zlib;
+#[cfg(not(feature = "no_std"))]
 use std::fs;
+#[cfg(not(feature = "no_std"))]
 use std::io;
+#[cfg(not(feature = "no_std"))]
 use std::io::Read;
+#[cfg(not(feature = "no_std"))]
 use std::io::Write;
+#[cfg(not(feature = "no_std"))]
 use std::process;
 
+#[cfg(feature = "no_std")]
+fn main() {}
+
+#[cfg(not(feature = "no_std"))]
 fn main() {
     let matches = App::new("deflate")
         .arg(

--- a/libflate_lz77/Cargo.toml
+++ b/libflate_lz77/Cargo.toml
@@ -16,6 +16,11 @@ coveralls = {repository = "sile/libflate"}
 
 [dependencies]
 rle-decode-fast = "1.0.0"
+core2 = { version = "0.4", default-features = false, features = ["alloc"], optional = true }
+hashbrown = { version = "0.13", optional = true }
 
 [dev-dependencies]
 libflate = { path = "../", version = "1" }
+
+[features]
+no_std = ["core2", "hashbrown"]

--- a/libflate_lz77/src/default.rs
+++ b/libflate_lz77/src/default.rs
@@ -1,5 +1,11 @@
-use std::cmp;
-use std::collections::HashMap;
+#[cfg(feature = "no_std")]
+use alloc::vec::Vec;
+#[cfg(feature = "no_std")]
+use core::cmp;
+#[cfg(feature = "no_std")]
+use hashbrown::HashMap;
+#[cfg(not(feature = "no_std"))]
+use std::{cmp, collections::HashMap};
 
 use super::Code;
 use super::Lz77Encode;

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "no_std")]
+use core2::io;
+#[cfg(not(feature = "no_std"))]
 use std::io;
 
 #[derive(Debug)]
@@ -176,6 +179,9 @@ pub(crate) struct BitReaderState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "no_std")]
+    use core2::io;
+    #[cfg(not(feature = "no_std"))]
     use std::io;
 
     #[test]

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -1,4 +1,7 @@
 use adler32::RollingAdler32;
+#[cfg(feature = "no_std")]
+use core::fmt;
+#[cfg(not(feature = "no_std"))]
 use std::fmt;
 
 pub struct Adler32(RollingAdler32);

--- a/src/deflate/decode.rs
+++ b/src/deflate/decode.rs
@@ -1,8 +1,10 @@
 use super::symbol;
 use crate::bit;
 use crate::lz77;
-use std::io;
-use std::io::Read;
+#[cfg(feature = "no_std")]
+use core2::io::{self, Read};
+#[cfg(not(feature = "no_std"))]
+use std::io::{self, Read};
 
 /// DEFLATE decoder.
 #[derive(Debug)]
@@ -21,6 +23,9 @@ where
     ///
     /// # Examples
     /// ```
+    /// #[cfg(feature = "no_std")]
+    /// use core2::io::{Cursor, Read};
+    /// #[cfg(not(feature = "no_std"))]
     /// use std::io::{Cursor, Read};
     /// use libflate::deflate::Decoder;
     ///
@@ -53,6 +58,9 @@ where
     ///
     /// # Examples
     /// ```
+    /// #[cfg(feature = "no_std")]
+    /// use core2::io::Cursor;
+    /// #[cfg(not(feature = "no_std"))]
     /// use std::io::Cursor;
     /// use libflate::deflate::Decoder;
     ///
@@ -90,7 +98,10 @@ where
                     if used != len.into() {
                         Err(io::Error::new(
                             io::ErrorKind::UnexpectedEof,
+                            #[cfg(not(feature = "no_std"))]
                             format!("The reader has incorrect length: expected {len}, read {used}"),
+                            #[cfg(feature = "no_std")]
+                            "The reader has incorrect length",
                         ))
                     } else {
                         Ok(())
@@ -155,8 +166,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "no_std"))]
     use super::*;
     use crate::deflate::symbol::{DynamicHuffmanCodec, HuffmanCodec};
+    #[cfg(not(feature = "no_std"))]
     use std::io;
 
     #[test]
@@ -177,6 +190,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "no_std"))]
     fn it_works() {
         let input = [
             180, 253, 73, 143, 28, 201, 150, 46, 8, 254, 150, 184, 139, 75, 18, 69, 247, 32, 157,
@@ -198,6 +212,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "no_std"))]
     fn test_issue_64() {
         let input = b"\x04\x04\x04\x05:\x1az*\xfc\x06\x01\x90\x01\x06\x01";
         let mut decoder = Decoder::new(&input[..]);

--- a/src/deflate/encode.rs
+++ b/src/deflate/encode.rs
@@ -3,8 +3,12 @@ use super::BlockType;
 use crate::bit;
 use crate::finish::{Complete, Finish};
 use crate::lz77;
-use std::cmp;
-use std::io;
+#[cfg(feature = "no_std")]
+use core::cmp;
+#[cfg(feature = "no_std")]
+use core2::io;
+#[cfg(not(feature = "no_std"))]
+use std::{cmp, io};
 
 /// The default size of a DEFLATE block.
 pub const DEFAULT_BLOCK_SIZE: usize = 1024 * 1024;
@@ -142,11 +146,14 @@ where
     ///
     /// # Examples
     /// ```
+    /// #[cfg(feature = "no_std")]
+    /// use core2::io::Write;
+    /// #[cfg(not(feature = "no_std"))]
     /// use std::io::Write;
     /// use libflate::deflate::Encoder;
     ///
     /// let mut encoder = Encoder::new(Vec::new());
-    /// encoder.write_all(b"Hello World!").unwrap();
+    /// encoder.write_all(b"Hello World!".as_ref()).unwrap();
     ///
     /// assert_eq!(encoder.finish().into_result().unwrap(),
     ///            [5, 192, 49, 13, 0, 0, 8, 3, 65, 43, 224, 6, 7, 24, 128, 237,
@@ -167,12 +174,15 @@ where
     ///
     /// # Examples
     /// ```
+    /// #[cfg(feature = "no_std")]
+    /// use core2::io::Write;
+    /// #[cfg(not(feature = "no_std"))]
     /// use std::io::Write;
     /// use libflate::deflate::{Encoder, EncodeOptions};
     ///
     /// let options = EncodeOptions::new().no_compression();
     /// let mut encoder = Encoder::with_options(Vec::new(), options);
-    /// encoder.write_all(b"Hello World!").unwrap();
+    /// encoder.write_all(b"Hello World!".as_ref()).unwrap();
     ///
     /// assert_eq!(encoder.finish().into_result().unwrap(),
     ///            [1, 12, 0, 243, 255, 72, 101, 108, 108, 111, 32, 87, 111,
@@ -189,11 +199,14 @@ where
     ///
     /// # Examples
     /// ```
+    /// #[cfg(feature = "no_std")]
+    /// use core2::io::Write;
+    /// #[cfg(not(feature = "no_std"))]
     /// use std::io::Write;
     /// use libflate::deflate::Encoder;
     ///
     /// let mut encoder = Encoder::new(Vec::new());
-    /// encoder.write_all(b"Hello World!").unwrap();
+    /// encoder.write_all(b"Hello World!".as_ref()).unwrap();
     ///
     /// assert_eq!(encoder.finish().into_result().unwrap(),
     ///            [5, 192, 49, 13, 0, 0, 8, 3, 65, 43, 224, 6, 7, 24, 128, 237,
@@ -428,6 +441,9 @@ where
 mod tests {
     use super::super::Decoder;
     use super::*;
+    #[cfg(feature = "no_std")]
+    use core2::io::{Read as _, Write as _};
+    #[cfg(not(feature = "no_std"))]
     use std::io::{Read as _, Write as _};
 
     #[test]

--- a/src/deflate/mod.rs
+++ b/src/deflate/mod.rs
@@ -4,12 +4,15 @@
 //!
 //! # Examples
 //! ```
-//! use std::io::{self, Read};
+//! #[cfg(feature = "no_std")]
+//! use core2::io::{Read, Write};
+//! #[cfg(not(feature = "no_std"))]
+//! use std::io::{Read, Write};
 //! use libflate::deflate::{Encoder, Decoder};
 //!
 //! // Encoding
 //! let mut encoder = Encoder::new(Vec::new());
-//! io::copy(&mut &b"Hello World!"[..], &mut encoder).unwrap();
+//! encoder.write_all(b"Hello World!".as_ref()).unwrap();
 //! let encoded_data = encoder.finish().into_result().unwrap();
 //!
 //! // Decoding
@@ -42,6 +45,9 @@ enum BlockType {
 mod tests {
     use super::*;
     use crate::lz77;
+    #[cfg(feature = "no_std")]
+    use core2::io::{Read, Write};
+    #[cfg(not(feature = "no_std"))]
     use std::io::{Read, Write};
 
     #[test]

--- a/src/finish.rs
+++ b/src/finish.rs
@@ -1,6 +1,14 @@
 //! `Finish` and related types.
-use std::io::{self, Write};
-use std::ops::{Deref, DerefMut};
+
+#[cfg(feature = "no_std")]
+use core::ops::{Deref, DerefMut};
+#[cfg(feature = "no_std")]
+use core2::io::{self, Write};
+#[cfg(not(feature = "no_std"))]
+use std::{
+    io::{self, Write},
+    ops::{Deref, DerefMut},
+};
 
 /// `Finish` is a type that represents a value which
 /// may have an error occurred during the computation.
@@ -104,14 +112,17 @@ impl<T: Complete> AutoFinish<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::io;
+    /// #[cfg(feature = "no_std")]
+    /// use core2::io::Write;
+    /// #[cfg(not(feature = "no_std"))]
+    /// use std::io::Write;
     /// use libflate::finish::AutoFinish;
     /// use libflate::gzip::Encoder;
     ///
     /// let plain = b"Hello World!";
     /// let mut buf = Vec::new();
     /// let mut encoder = AutoFinish::new(Encoder::new(&mut buf).unwrap());
-    /// io::copy(&mut &plain[..], &mut encoder).unwrap();
+    /// encoder.write_all(plain.as_ref()).unwrap();
     /// ```
     pub fn new(inner: T) -> Self {
         AutoFinish { inner: Some(inner) }
@@ -166,14 +177,17 @@ impl<T: Complete> AutoFinishUnchecked<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::io;
+    /// #[cfg(feature = "no_std")]
+    /// use core2::io::Write;
+    /// #[cfg(not(feature = "no_std"))]
+    /// use std::io::Write;
     /// use libflate::finish::AutoFinishUnchecked;
     /// use libflate::gzip::Encoder;
     ///
     /// let plain = b"Hello World!";
     /// let mut buf = Vec::new();
     /// let mut encoder = AutoFinishUnchecked::new(Encoder::new(&mut buf).unwrap());
-    /// io::copy(&mut &plain[..], &mut encoder).unwrap();
+    /// encoder.write_all(plain.as_ref()).unwrap();
     /// ```
     pub fn new(inner: T) -> Self {
         AutoFinishUnchecked { inner: Some(inner) }

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -1,7 +1,13 @@
 //! Length-limited Huffman Codes.
 use crate::bit;
-use std::cmp;
-use std::io;
+#[cfg(feature = "no_std")]
+use alloc::vec::Vec;
+#[cfg(feature = "no_std")]
+use core::cmp;
+#[cfg(feature = "no_std")]
+use core2::io;
+#[cfg(not(feature = "no_std"))]
+use std::{cmp, io};
 
 const MAX_BITWIDTH: u8 = 15;
 
@@ -106,10 +112,13 @@ impl Builder for DecoderBuilder {
         for padding in 0..(1 << (self.max_bitwidth - code.width)) {
             let i = ((padding << code.width) | code_be.bits) as usize;
             if self.table[i] != u16::from(MAX_BITWIDTH) + 1 {
+                #[cfg(not(feature = "no_std"))]
                 let message = format!(
                     "Bit region conflict: i={}, old_value={}, new_value={}, symbol={}, code={:?}",
                     i, self.table[i], value, symbol, code
                 );
+                #[cfg(feature = "no_std")]
+                let message = "Bit region conflict";
                 return Err(io::Error::new(io::ErrorKind::InvalidData, message));
             }
             self.table[i] = value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,30 @@
 //! A Rust implementation of DEFLATE algorithm and related formats (ZLIB, GZIP).
+
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(no_std, feature = "no_std")]
+
 pub use finish::Finish;
 
+#[cfg(feature = "no_std")]
+extern crate alloc;
+
+#[cfg(not(feature = "no_std"))]
 macro_rules! invalid_data_error {
     ($fmt:expr) => { invalid_data_error!("{}", $fmt) };
     ($fmt:expr, $($arg:tt)*) => {
         ::std::io::Error::new(::std::io::ErrorKind::InvalidData, format!($fmt, $($arg)*))
     }
+}
+
+#[cfg(feature = "no_std")]
+macro_rules! invalid_data_error {
+    ($fmt:expr) => {
+        invalid_data_error!($fmt, "")
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        ::core2::io::Error::new(::core2::io::ErrorKind::InvalidData, $fmt)
+    };
 }
 
 macro_rules! finish_try {

--- a/src/non_blocking/deflate/mod.rs
+++ b/src/non_blocking/deflate/mod.rs
@@ -4,13 +4,16 @@
 //!
 //! # Examples
 //! ```
-//! use std::io::{self, Read};
+//! #[cfg(feature = "no_std")]
+//! use core2::io::{Read, Write};
+//! #[cfg(not(feature = "no_std"))]
+//! use std::io::{Read, Write};
 //! use libflate::deflate::Encoder;
 //! use libflate::non_blocking::deflate::Decoder;
 //!
 //! // Encoding
 //! let mut encoder = Encoder::new(Vec::new());
-//! io::copy(&mut &b"Hello World!"[..], &mut encoder).unwrap();
+//! encoder.write_all(b"Hello World!".as_ref()).unwrap();
 //! let encoded_data = encoder.finish().into_result().unwrap();
 //!
 //! // Decoding

--- a/src/non_blocking/transaction.rs
+++ b/src/non_blocking/transaction.rs
@@ -1,6 +1,15 @@
 use crate::bit;
-use std::cmp;
-use std::io::{self, Read};
+#[cfg(feature = "no_std")]
+use alloc::vec::Vec;
+#[cfg(feature = "no_std")]
+use core::cmp;
+#[cfg(feature = "no_std")]
+use core2::io::{self, Read};
+#[cfg(not(feature = "no_std"))]
+use std::{
+    cmp,
+    io::{self, Read},
+};
 
 #[derive(Debug)]
 pub struct TransactionalBitReader<R> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,6 @@
-#[cfg(test)]
+#[cfg(all(test, feature = "no_std"))]
+use core2::io::{self, Read};
+#[cfg(all(test, not(feature = "no_std")))]
 use std::io::{self, Read};
 
 #[cfg(test)]


### PR DESCRIPTION
Introduce a new, default `std` feature to the library, and conditionally use structures and traits from `no_std` compatible libraries.

Existing `std` users can continue using the library with no changes. `no_std` users can import the library using `default_features = false`.

Changes were testing by running the test suite using the `std` and `no_std` configurations:

```bash
# std build/test
cargo build
cargo test

# no_std build/test
cargo build --no-default-features
cargo test --no-default-features
```