### PR TITLE
specify clap version in flate_bench

### DIFF
--- a/flate_bench/Cargo.toml
+++ b/flate_bench/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Takeru Ohta <phjgt308@gmail.com>"]
 
 [dependencies]
-clap = "*"
+clap = "3"
 flate2 = "*"
 inflate = "*"
 libflate = {path = "../"}


### PR DESCRIPTION
Specify clap version in flate_bench as clap4 has been released with a new api