### PR TITLE
Update hashbrown to 0.14

### DIFF
--- a/libflate_lz77/Cargo.toml
+++ b/libflate_lz77/Cargo.toml
@@ -17,7 +17,7 @@ coveralls = {repository = "sile/libflate"}
 [dependencies]
 rle-decode-fast = "1.0.0"
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }
-hashbrown = { version = "0.13" }
+hashbrown = { version = "0.14" }
 
 [dev-dependencies]
 libflate = { path = "../", version = "2.0", default-features = false }


### PR DESCRIPTION
Rationale: This crate is the only one left still using hashbrown 0.13 in our dependency tree.
See: https://github.com/ruffle-rs/ruffle/actions/runs/8893158948/job/24418772750?pr=16168#step:5:547
Changelog entry: https://github.com/rust-lang/hashbrown/blob/master/CHANGELOG.md#v0140---2023-06-01