### PR TITLE
Exclude test data from published packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,12 @@ keywords = ["deflate", "gzip", "zlib"]
 categories = ["compression", "no-std"]
 license = "MIT"
 edition = "2021"
+include = [
+	'Cargo.toml',
+        'README.md',
+        'LICENSE',
+        'src/**/*.rs',
+]
 
 [dependencies]
 adler32 = { version = "1", default-features = false }


### PR DESCRIPTION
During a review of our dependencies we noticed that the libflate crate contains test data in the published versions. It would be great to exclude them to avoid situtations like that xz incident some time back. It also slightly decreases the package size, although that's not significant.