### PR TITLE
Upgrade Rust edition to 2024

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         features: [--no-default-features, --all-features]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install ${{ matrix.toolchain }} toolchain
         run: |
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install nightly toolchain
         run: |
@@ -54,7 +54,7 @@ jobs:
         features: [--no-default-features, --all-features]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install ${{ matrix.toolchain }} toolchain
         run: |
@@ -73,7 +73,7 @@ jobs:
         features: [--no-default-features, --all-features]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install ${{ matrix.toolchain }} toolchain
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - id: create-release
         run: gh release create ${{ github.ref_name }} --title "${{ github.ref_name }}" --generate-notes
         env:
@@ -23,7 +23,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
       - run: cargo publish

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["deflate", "gzip", "zlib"]
 categories = ["compression", "no-std"]
 license = "MIT"
-edition = "2021"
+edition = "2024"
 include = [
   "Cargo.toml",
   "README.md",
@@ -37,4 +37,3 @@ exclude = ["flate_bench"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
-

--- a/flate_bench/Cargo.toml
+++ b/flate_bench/Cargo.toml
@@ -2,7 +2,7 @@
 name = "flate_bench"
 version = "0.1.0"
 authors = ["Takeru Ohta <phjgt308@gmail.com>"]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/libflate_lz77/Cargo.toml
+++ b/libflate_lz77/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libflate_lz77"
 version = "2.2.0"
 authors = ["Takeru Ohta <phjgt308@gmail.com>"]
-edition = "2021"
+edition = "2024"
 description = "LZ77 encoder for libflate crate"
 homepage = "https://github.com/sile/libflate"
 repository = "https://github.com/sile/libflate"

--- a/src/deflate/encode.rs
+++ b/src/deflate/encode.rs
@@ -1,5 +1,5 @@
-use super::symbol;
 use super::BlockType;
+use super::symbol;
 use crate::bit;
 use crate::finish::{Complete, Finish};
 use crate::lz77;

--- a/src/deflate/mod.rs
+++ b/src/deflate/mod.rs
@@ -20,9 +20,9 @@
 //! assert_eq!(decoded_data, b"Hello World!");
 //! ```
 pub use self::decode::Decoder;
+pub use self::encode::DEFAULT_BLOCK_SIZE;
 pub use self::encode::EncodeOptions;
 pub use self::encode::Encoder;
-pub use self::encode::DEFAULT_BLOCK_SIZE;
 
 mod decode;
 mod encode;

--- a/src/finish.rs
+++ b/src/finish.rs
@@ -125,11 +125,10 @@ impl<T: Complete> AutoFinish<T> {
 }
 impl<T: Complete> Drop for AutoFinish<T> {
     fn drop(&mut self) {
-        if let Some(inner) = self.inner.take() {
-            if let Err(e) = inner.complete() {
+        if let Some(inner) = self.inner.take()
+            && let Err(e) = inner.complete() {
                 panic!("{}", e);
             }
-        }
     }
 }
 impl<T: Complete> Deref for AutoFinish<T> {

--- a/src/finish.rs
+++ b/src/finish.rs
@@ -126,9 +126,10 @@ impl<T: Complete> AutoFinish<T> {
 impl<T: Complete> Drop for AutoFinish<T> {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.take()
-            && let Err(e) = inner.complete() {
-                panic!("{}", e);
-            }
+            && let Err(e) = inner.complete()
+        {
+            panic!("{}", e);
+        }
     }
 }
 impl<T: Complete> Deref for AutoFinish<T> {

--- a/src/non_blocking/deflate/decode.rs
+++ b/src/non_blocking/deflate/decode.rs
@@ -240,7 +240,7 @@ impl Read for BlockDecoder {
 mod tests {
     use super::*;
     use crate::deflate::{EncodeOptions, Encoder};
-    use crate::util::{nb_read_to_end, WouldBlockReader};
+    use crate::util::{WouldBlockReader, nb_read_to_end};
     use alloc::{format, string::String, vec::Vec};
     use core2::io::{Read, Write};
 

--- a/src/non_blocking/gzip.rs
+++ b/src/non_blocking/gzip.rs
@@ -156,7 +156,7 @@ impl<R: Read> Read for Decoder<R> {
 mod tests {
     use super::*;
     use crate::gzip::Encoder;
-    use crate::util::{nb_read_to_end, WouldBlockReader};
+    use crate::util::{WouldBlockReader, nb_read_to_end};
     use alloc::vec::Vec;
     use core2::io::Write;
 

--- a/src/non_blocking/zlib.rs
+++ b/src/non_blocking/zlib.rs
@@ -155,7 +155,7 @@ impl<R: Read> Read for Decoder<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::util::{nb_read_to_end, WouldBlockReader};
+    use crate::util::{WouldBlockReader, nb_read_to_end};
     use crate::zlib::{EncodeOptions, Encoder};
     use alloc::vec::Vec;
     use core2::io::Write;


### PR DESCRIPTION
This PR updates the project to Rust edition 2024 and upgrades the `actions/checkout` action from v5 to v6 across all CI/CD workflows. Additionally, it refactors nested `if let` statements in `src/finish.rs` to use Rust 2024's `let...else` chaining syntax, and removes trailing whitespace.

### Changes:
- **Workflows**: Updated `actions/checkout` from v5 to v6 in `ci.yml` and `release.yml`
- **Edition**: Bumped Rust edition from 2021 to 2024 in `Cargo.toml`, `flate_bench/Cargo.toml`, and `libflate_lz77/Cargo.toml`
- **Code modernization**: Refactored `Drop` impl in `src/finish.rs` to use new `let...else` chaining (Rust 2024 feature)
- **Cleanup**: Removed trailing blank line in `Cargo.toml`
