### PR TITLE
Fix `invalid_data_error!` macro to properly format error messages with arguments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,10 @@ macro_rules! invalid_data_error {
         ::core2::io::Error::new(::core2::io::ErrorKind::InvalidData, $fmt)
     };
     ($fmt:expr, $($arg:tt)*) => {
-        ::core2::io::Error::new(::core2::io::ErrorKind::InvalidData, format!($fmt, $($arg)*))
+        ::core2::io::Error::new(
+            ::core2::io::ErrorKind::InvalidData,
+            ::alloc::format!($fmt, $($arg)*),
+        )
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,10 @@ extern crate alloc;
 
 macro_rules! invalid_data_error {
     ($fmt:expr) => {
-        invalid_data_error!($fmt, "")
+        ::core2::io::Error::new(::core2::io::ErrorKind::InvalidData, $fmt)
     };
     ($fmt:expr, $($arg:tt)*) => {
-        ::core2::io::Error::new(::core2::io::ErrorKind::InvalidData, $fmt)
+        ::core2::io::Error::new(::core2::io::ErrorKind::InvalidData, format!($fmt, $($arg)*))
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,19 @@ macro_rules! invalid_data_error {
         ::core2::io::Error::new(::core2::io::ErrorKind::InvalidData, $fmt)
     };
     ($fmt:expr, $($arg:tt)*) => {
-        ::core2::io::Error::new(
-            ::core2::io::ErrorKind::InvalidData,
-            ::alloc::format!($fmt, $($arg)*),
-        )
+        {
+            #[cfg(feature = "std")]
+            {
+                ::core2::io::Error::new(
+                    ::core2::io::ErrorKind::InvalidData,
+                    ::alloc::format!($fmt, $($arg)*),
+                )
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                ::core2::io::Error::new(::core2::io::ErrorKind::InvalidData, $fmt)
+            }
+        }
     };
 }
 

--- a/src/zlib.rs
+++ b/src/zlib.rs
@@ -932,4 +932,12 @@ mod tests {
         ];
         assert_eq!(buf, decoded_data);
     }
+
+    #[test]
+    fn issue_82() {
+        let encoded_data = [0x00, 0x00];
+        let error = Header::read_from(&encoded_data[..]).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("method=0"));
+    }
 }

--- a/src/zlib.rs
+++ b/src/zlib.rs
@@ -934,6 +934,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn issue_82() {
         let encoded_data = [0x00, 0x00];
         let error = Header::read_from(&encoded_data[..]).unwrap_err();


### PR DESCRIPTION
  The `invalid_data_error!` macro was dropping variadic format arguments (`$arg`), so error messages lost runtime context (for example, values like `method=0`).

  ### Changes
  - Fixed the single-argument arm to construct `InvalidData` errors directly.
  - Fixed the variadic arm for `std` builds to format messages with `::alloc::format!($fmt, ...)`.
  - Added `cfg` handling so `no_std` builds remain compatible with `core2::io::Error::new` (which requires `&'static str` in that mode).
  - Added a regression test for issue #82 (`zlib::tests::issue_82`) to ensure formatted values appear in error messages.

Closes #82