### PR TITLE
Replace yanked core2 dependency with no_std_io2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ adler32 = { version = "1", default-features = false }
 crc32fast = { version = "1.1.1", default-features = false }
 dary_heap = "0.3.5"
 libflate_lz77 = { path = "libflate_lz77", version = "2.2.0", default-features = false }
-core2 = { version = "0.4", default-features = false, features = ["alloc"] }
+no_std_io2 = { version = "0.9", default-features = false, features = ["alloc"] }
 
 [features]
 default = ["std"]
-std = ["libflate_lz77/std", "core2/std"]
+std = ["libflate_lz77/std", "no_std_io2/std"]
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/libflate_lz77/Cargo.toml
+++ b/libflate_lz77/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 
 [dependencies]
 rle-decode-fast = "1.0.0"
-core2 = { version = "0.4", default-features = false, features = ["alloc"] }
+no_std_io2 = { version = "0.9", default-features = false, features = ["alloc"] }
 hashbrown = { version = "0.16" }
 
 [dev-dependencies]
@@ -21,4 +21,4 @@ libflate = { path = "../", version = "2.0", default-features = false }
 
 [features]
 default = ["std"]
-std = ["core2/std", "libflate/std"]
+std = ["no_std_io2/std", "libflate/std"]

--- a/libflate_lz77/src/lib.rs
+++ b/libflate_lz77/src/lib.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 pub use self::default::{DefaultLz77Encoder, DefaultLz77EncoderBuilder};
 use alloc::vec::Vec;
 use core::cmp;
-use core2::io;
+use no_std_io2::io;
 use rle_decode_fast::rle_decode;
 
 mod default;
@@ -248,7 +248,7 @@ impl io::Read for Lz77Decoder {
 mod tests {
     use super::*;
     use alloc::vec::Vec;
-    use core2::io::Read as _;
+    use no_std_io2::io::Read as _;
 
     #[test]
     fn encoder_and_decoder_works() {

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -1,4 +1,4 @@
-use core2::io;
+use no_std_io2::io;
 
 #[derive(Debug)]
 pub struct BitWriter<W> {
@@ -177,7 +177,7 @@ pub(crate) struct BitReaderState {
 mod tests {
     use super::*;
     use alloc::vec::Vec;
-    use core2::io;
+    use no_std_io2::io;
 
     #[test]
     fn writer_works() {

--- a/src/deflate/decode.rs
+++ b/src/deflate/decode.rs
@@ -1,7 +1,7 @@
 use super::symbol;
 use crate::bit;
 use crate::lz77;
-use core2::io::{self, Read};
+use no_std_io2::io::{self, Read};
 
 /// DEFLATE decoder.
 #[derive(Debug)]
@@ -22,7 +22,7 @@ where
     /// ```
     /// # extern crate alloc;
     /// # use alloc::vec::Vec;
-    /// use core2::io::{Cursor, Read};
+    /// use no_std_io2::io::{Cursor, Read};
     /// use libflate::deflate::Decoder;
     ///
     /// let encoded_data = [243, 72, 205, 201, 201, 87, 8, 207, 47, 202, 73, 81, 4, 0];
@@ -54,7 +54,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Cursor;
+    /// use no_std_io2::io::Cursor;
     /// use libflate::deflate::Decoder;
     ///
     /// let encoded_data = [243, 72, 205, 201, 201, 87, 8, 207, 47, 202, 73, 81, 4, 0];

--- a/src/deflate/encode.rs
+++ b/src/deflate/encode.rs
@@ -5,7 +5,7 @@ use crate::finish::{Complete, Finish};
 use crate::lz77;
 use alloc::vec::Vec;
 use core::cmp;
-use core2::io;
+use no_std_io2::io;
 
 /// The default size of a DEFLATE block.
 pub const DEFAULT_BLOCK_SIZE: usize = 1024 * 1024;
@@ -143,7 +143,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Write;
+    /// use no_std_io2::io::Write;
     /// use libflate::deflate::Encoder;
     ///
     /// let mut encoder = Encoder::new(Vec::new());
@@ -168,7 +168,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Write;
+    /// use no_std_io2::io::Write;
     /// use libflate::deflate::{Encoder, EncodeOptions};
     ///
     /// let options = EncodeOptions::new().no_compression();
@@ -190,7 +190,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Write;
+    /// use no_std_io2::io::Write;
     /// use libflate::deflate::Encoder;
     ///
     /// let mut encoder = Encoder::new(Vec::new());
@@ -429,7 +429,7 @@ where
 mod tests {
     use super::super::Decoder;
     use super::*;
-    use core2::io::{Read as _, Write as _};
+    use no_std_io2::io::{Read as _, Write as _};
 
     #[test]
     fn test_issues_52() {

--- a/src/deflate/mod.rs
+++ b/src/deflate/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! # Examples
 //! ```
-//! use core2::io::{Read, Write};
+//! use no_std_io2::io::{Read, Write};
 //! use libflate::deflate::{Encoder, Decoder};
 //!
 //! // Encoding
@@ -43,7 +43,7 @@ mod tests {
     use super::*;
     use crate::lz77;
     use alloc::vec::Vec;
-    use core2::io::{Read, Write};
+    use no_std_io2::io::{Read, Write};
 
     #[test]
     fn encode_and_decode_works() {

--- a/src/deflate/symbol.rs
+++ b/src/deflate/symbol.rs
@@ -4,7 +4,7 @@ use crate::huffman::Builder;
 use crate::lz77;
 use alloc::{boxed::Box, vec::Vec};
 use core::{cmp, iter, ops::Range};
-use core2::io;
+use no_std_io2::io;
 
 const FIXED_LITERAL_OR_LENGTH_CODE_TABLE: [(u8, Range<u16>, u16); 4] = [
     (8, 000..144, 0b0_0011_0000),

--- a/src/finish.rs
+++ b/src/finish.rs
@@ -1,7 +1,7 @@
 //! `Finish` and related types.
 
 use core::ops::{Deref, DerefMut};
-use core2::io::{self, Write};
+use no_std_io2::io::{self, Write};
 
 /// `Finish` is a type that represents a value which
 /// may have an error occurred during the computation.
@@ -105,7 +105,7 @@ impl<T: Complete> AutoFinish<T> {
     /// # Examples
     ///
     /// ```
-    /// use core2::io::Write;
+    /// use no_std_io2::io::Write;
     /// use libflate::finish::AutoFinish;
     /// use libflate::gzip::Encoder;
     ///
@@ -167,7 +167,7 @@ impl<T: Complete> AutoFinishUnchecked<T> {
     /// # Examples
     ///
     /// ```
-    /// use core2::io::Write;
+    /// use no_std_io2::io::Write;
     /// use libflate::finish::AutoFinishUnchecked;
     /// use libflate::gzip::Encoder;
     ///

--- a/src/gzip.rs
+++ b/src/gzip.rs
@@ -4,7 +4,7 @@
 //!
 //! # Examples
 //! ```
-//! use core2::io::{Read, Write};
+//! use no_std_io2::io::{Read, Write};
 //! use libflate::gzip::{Encoder, Decoder};
 //!
 //! // Encoding
@@ -24,7 +24,7 @@ use crate::deflate;
 use crate::finish::{Complete, Finish};
 use crate::lz77;
 use alloc::{ffi::CString, vec::Vec};
-use core2::io;
+use no_std_io2::io;
 #[cfg(feature = "std")]
 use std::time;
 
@@ -767,7 +767,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Write;
+    /// use no_std_io2::io::Write;
     /// use libflate::gzip::Encoder;
     ///
     /// let mut encoder = Encoder::new(Vec::new()).unwrap();
@@ -789,7 +789,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Write;
+    /// use no_std_io2::io::Write;
     /// use libflate::gzip::{Encoder, EncodeOptions, HeaderBuilder};
     ///
     /// let header = HeaderBuilder::new().modification_time(123).finish();
@@ -828,7 +828,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Write;
+    /// use no_std_io2::io::Write;
     /// use libflate::gzip::Encoder;
     ///
     /// let mut encoder = Encoder::new(Vec::new()).unwrap();
@@ -843,7 +843,7 @@ where
     /// it may be convenient to use `AutoFinishUnchecked` instead of the explicit invocation of this method.
     ///
     /// ```
-    /// use core2::io::Write;
+    /// use no_std_io2::io::Write;
     /// use libflate::finish::AutoFinishUnchecked;
     /// use libflate::gzip::Encoder;
     ///
@@ -925,7 +925,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Read;
+    /// use no_std_io2::io::Read;
     /// use libflate::gzip::Decoder;
     ///
     /// let encoded_data = [31, 139, 8, 0, 123, 0, 0, 0, 0, 3, 1, 12, 0, 243, 255,
@@ -974,7 +974,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Cursor;
+    /// use no_std_io2::io::Cursor;
     /// use libflate::gzip::Decoder;
     ///
     /// let encoded_data = [31, 139, 8, 0, 123, 0, 0, 0, 0, 3, 1, 12, 0, 243, 255,
@@ -1063,7 +1063,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Read;
+    /// use no_std_io2::io::Read;
     /// use libflate::gzip::MultiDecoder;
     ///
     /// let mut encoded_data = Vec::new();
@@ -1121,7 +1121,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Cursor;
+    /// use no_std_io2::io::Cursor;
     /// use libflate::gzip::MultiDecoder;
     ///
     /// let encoded_data = [31, 139, 8, 0, 123, 0, 0, 0, 0, 3, 1, 12, 0, 243, 255,
@@ -1171,7 +1171,7 @@ mod tests {
     use super::*;
     use crate::finish::AutoFinish;
     use alloc::{vec, vec::Vec};
-    use core2::io::{Read, Write};
+    use no_std_io2::io::{Read, Write};
 
     fn decode(buf: &[u8]) -> io::Result<Vec<u8>> {
         let mut decoder = Decoder::new(buf).unwrap();

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -2,7 +2,7 @@
 use crate::bit;
 use alloc::{vec, vec::Vec};
 use core::cmp;
-use core2::io;
+use no_std_io2::io;
 
 const MAX_BITWIDTH: u8 = 15;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,20 +9,20 @@ extern crate alloc;
 
 macro_rules! invalid_data_error {
     ($fmt:expr) => {
-        ::core2::io::Error::new(::core2::io::ErrorKind::InvalidData, $fmt)
+        ::no_std_io2::io::Error::new(::no_std_io2::io::ErrorKind::InvalidData, $fmt)
     };
     ($fmt:expr, $($arg:tt)*) => {
         {
             #[cfg(feature = "std")]
             {
-                ::core2::io::Error::new(
-                    ::core2::io::ErrorKind::InvalidData,
+                ::no_std_io2::io::Error::new(
+                    ::no_std_io2::io::ErrorKind::InvalidData,
                     ::alloc::format!($fmt, $($arg)*),
                 )
             }
             #[cfg(not(feature = "std"))]
             {
-                ::core2::io::Error::new(::core2::io::ErrorKind::InvalidData, $fmt)
+                ::no_std_io2::io::Error::new(::no_std_io2::io::ErrorKind::InvalidData, $fmt)
             }
         }
     };

--- a/src/non_blocking/deflate/decode.rs
+++ b/src/non_blocking/deflate/decode.rs
@@ -2,7 +2,7 @@ use crate::deflate::symbol::{self, HuffmanCodec};
 use crate::lz77;
 use crate::non_blocking::transaction::TransactionalBitReader;
 use core::cmp;
-use core2::io::{self, Read};
+use no_std_io2::io::{self, Read};
 /// DEFLATE decoder which supports non-blocking I/O.
 #[derive(Debug)]
 pub struct Decoder<R> {
@@ -18,7 +18,7 @@ impl<R: Read> Decoder<R> {
     ///
     /// # Examples
     /// ```
-    /// use core2::io::{Cursor, Read};
+    /// use no_std_io2::io::{Cursor, Read};
     /// use libflate::non_blocking::deflate::Decoder;
     ///
     /// let encoded_data = [243, 72, 205, 201, 201, 87, 8, 207, 47, 202, 73, 81, 4, 0];
@@ -51,7 +51,7 @@ impl<R: Read> Decoder<R> {
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Cursor;
+    /// use no_std_io2::io::Cursor;
     /// use libflate::non_blocking::deflate::Decoder;
     ///
     /// let encoded_data = [243, 72, 205, 201, 201, 87, 8, 207, 47, 202, 73, 81, 4, 0];
@@ -242,7 +242,7 @@ mod tests {
     use crate::deflate::{EncodeOptions, Encoder};
     use crate::util::{WouldBlockReader, nb_read_to_end};
     use alloc::{format, string::String, vec::Vec};
-    use core2::io::{Read, Write};
+    use no_std_io2::io::{Read, Write};
 
     #[test]
     fn it_works() {

--- a/src/non_blocking/deflate/mod.rs
+++ b/src/non_blocking/deflate/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! # Examples
 //! ```
-//! use core2::io::{Read, Write};
+//! use no_std_io2::io::{Read, Write};
 //! use libflate::deflate::Encoder;
 //! use libflate::non_blocking::deflate::Decoder;
 //!

--- a/src/non_blocking/gzip.rs
+++ b/src/non_blocking/gzip.rs
@@ -4,7 +4,7 @@
 //!
 //! # Examples
 //! ```
-//! use core2::io::{Read, Write};
+//! use no_std_io2::io::{Read, Write};
 //! use libflate::gzip::Encoder;
 //! use libflate::non_blocking::gzip::Decoder;
 //!
@@ -23,7 +23,7 @@
 use crate::checksum;
 use crate::gzip::{Header, Trailer};
 use crate::non_blocking::deflate;
-use core2::io::{self, Read};
+use no_std_io2::io::{self, Read};
 
 /// GZIP decoder which supports non-blocking I/O.
 #[derive(Debug)]
@@ -40,7 +40,7 @@ impl<R: Read> Decoder<R> {
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Read;
+    /// use no_std_io2::io::Read;
     /// use libflate::non_blocking::gzip::Decoder;
     ///
     /// let encoded_data = [31, 139, 8, 0, 123, 0, 0, 0, 0, 3, 1, 12, 0, 243, 255,
@@ -103,7 +103,7 @@ impl<R: Read> Decoder<R> {
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Cursor;
+    /// use no_std_io2::io::Cursor;
     /// use libflate::non_blocking::gzip::Decoder;
     ///
     /// let encoded_data = [31, 139, 8, 0, 123, 0, 0, 0, 0, 3, 1, 12, 0, 243, 255,
@@ -158,7 +158,7 @@ mod tests {
     use crate::gzip::Encoder;
     use crate::util::{WouldBlockReader, nb_read_to_end};
     use alloc::vec::Vec;
-    use core2::io::Write;
+    use no_std_io2::io::Write;
 
     fn decode_all(buf: &[u8]) -> io::Result<Vec<u8>> {
         let decoder = Decoder::new(WouldBlockReader::new(buf));

--- a/src/non_blocking/transaction.rs
+++ b/src/non_blocking/transaction.rs
@@ -1,7 +1,7 @@
 use crate::bit;
 use alloc::vec::Vec;
 use core::cmp;
-use core2::io::{self, Read};
+use no_std_io2::io::{self, Read};
 
 #[derive(Debug)]
 pub struct TransactionalBitReader<R> {

--- a/src/non_blocking/zlib.rs
+++ b/src/non_blocking/zlib.rs
@@ -4,7 +4,7 @@
 //!
 //! # Examples
 //! ```
-//! use core2::io::{Read, Write};
+//! use no_std_io2::io::{Read, Write};
 //! use libflate::zlib::Encoder;
 //! use libflate::non_blocking::zlib::Decoder;
 //!
@@ -23,7 +23,7 @@
 use crate::checksum;
 use crate::non_blocking::deflate;
 use crate::zlib::Header;
-use core2::io::{self, Read};
+use no_std_io2::io::{self, Read};
 
 /// ZLIB decoder which supports non-blocking I/O.
 #[derive(Debug)]
@@ -40,7 +40,7 @@ impl<R: Read> Decoder<R> {
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Read;
+    /// use no_std_io2::io::Read;
     /// use libflate::non_blocking::zlib::Decoder;
     ///
     /// let encoded_data = [120, 156, 243, 72, 205, 201, 201, 87, 8, 207, 47,
@@ -102,7 +102,7 @@ impl<R: Read> Decoder<R> {
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Cursor;
+    /// use no_std_io2::io::Cursor;
     /// use libflate::non_blocking::zlib::Decoder;
     ///
     /// let encoded_data = [120, 156, 243, 72, 205, 201, 201, 87, 8, 207, 47,
@@ -158,7 +158,7 @@ mod tests {
     use crate::util::{WouldBlockReader, nb_read_to_end};
     use crate::zlib::{EncodeOptions, Encoder};
     use alloc::vec::Vec;
-    use core2::io::Write;
+    use no_std_io2::io::Write;
 
     fn decode_all(buf: &[u8]) -> io::Result<Vec<u8>> {
         let decoder = Decoder::new(WouldBlockReader::new(buf));

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,7 @@
 pub(crate) mod testonly {
     use alloc::vec;
     use alloc::vec::Vec;
-    use core2::io::{self, Read};
+    use no_std_io2::io::{self, Read};
 
     pub struct WouldBlockReader<R> {
         inner: R,

--- a/src/zlib.rs
+++ b/src/zlib.rs
@@ -4,7 +4,7 @@
 //!
 //! # Examples
 //! ```
-//! use core2::io::{Read, Write};
+//! use no_std_io2::io::{Read, Write};
 //! use libflate::zlib::{Encoder, Decoder};
 //!
 //! // Encoding
@@ -23,7 +23,7 @@ use crate::checksum;
 use crate::deflate;
 use crate::finish::{Complete, Finish};
 use crate::lz77;
-use core2::io;
+use no_std_io2::io;
 
 const COMPRESSION_METHOD_DEFLATE: u8 = 8;
 
@@ -297,7 +297,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Read;
+    /// use no_std_io2::io::Read;
     /// use libflate::zlib::Decoder;
     ///
     /// let encoded_data = [120, 156, 243, 72, 205, 201, 201, 87, 8, 207, 47,
@@ -350,7 +350,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Cursor;
+    /// use no_std_io2::io::Cursor;
     /// use libflate::zlib::Decoder;
     ///
     /// let encoded_data = [120, 156, 243, 72, 205, 201, 201, 87, 8, 207, 47,
@@ -538,7 +538,7 @@ where
     /// #[cfg(feature = "std")]
     /// use std::io::Write;
     /// #[cfg(not(feature = "std"))]
-    /// use core2::io::Write;
+    /// use no_std_io2::io::Write;
     /// use libflate::zlib::Encoder;
     ///
     /// let mut encoder = Encoder::new(Vec::new()).unwrap();
@@ -563,7 +563,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Write;
+    /// use no_std_io2::io::Write;
     /// use libflate::zlib::{Encoder, EncodeOptions};
     ///
     /// let options = EncodeOptions::new().no_compression();
@@ -601,7 +601,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use core2::io::Write;
+    /// use no_std_io2::io::Write;
     /// use libflate::zlib::Encoder;
     ///
     /// let mut encoder = Encoder::new(Vec::new()).unwrap();
@@ -618,7 +618,7 @@ where
     /// it may be convenient to use `AutoFinishUnchecked` instead of the explicit invocation of this method.
     ///
     /// ```
-    /// use core2::io::Write;
+    /// use no_std_io2::io::Write;
     /// use libflate::finish::AutoFinishUnchecked;
     /// use libflate::zlib::Encoder;
     ///
@@ -685,7 +685,7 @@ mod tests {
     use super::*;
     use crate::finish::AutoFinish;
     use alloc::{borrow::ToOwned, string::ToString, vec, vec::Vec};
-    use core2::io::{Read as _, Write as _};
+    use no_std_io2::io::{Read as _, Write as _};
 
     fn decode_all(buf: &[u8]) -> io::Result<Vec<u8>> {
         let mut decoder = Decoder::new(buf).unwrap();


### PR DESCRIPTION
Disclaimer: I am not very knowledgeable in these parts of the ecosystem and used coding agents for support (GLM 5.1 on company hardware). I worked closely with the agent and reviewed the code. To the best of my knowledge and ability, this PR is clean and makes sense.

## Context

All versions of `core2` have been yanked from crates.io and its repo is archived. The author suggests "use `core` directly," but `core::io` doesn't provide `Read`/`Write`/`Error`/`ErrorKind` etc. yet, so that's not viable today.

[`no_std_io2`](https://github.com/wcampbell0x2a/no-std-io2) seems like the most actively maintained drop-in replacement with an identical API. The `Read` and `Write` traits are byte-for-byte identical to `core2`'s, and all needed types (`Error`, `ErrorKind`, `Cursor`, `Take`, `Result`) are present with the same semantics. The `std` feature flag works the same way — it re-exports `std::io` when enabled.

The only differences are additive: `Error::new()` is generic (accepts any error type, not just `&str`), `ErrorKind` has two extra variants (`Unsupported`, `OutOfMemory`), `Cursor<Vec<u8>>` implements `Write`, and there's a `memchr` transitive dep.

## Summary of changes

Migration was a simple `core2 → no_std_io2` rename — no logic changes. All 43 unit tests and 70 doc tests pass. Both `std` and `no_std` builds compile cleanly.

## Alternatives
There is also [`no_std_io`](https://github.com/no-std-io/no-std-io) of which `no_std_io2` is the direct fork. `no_std_io` has slightly more stars (10 vs 8) but the last commit is 3 years old vs. 4 months for `no_std_io2`. This is why I went with `no_std_io2`

Close #85 