### PR TITLE
set rust version to 1.85.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 keywords = ["deflate", "gzip", "zlib"]
 categories = ["compression", "no-std"]
 license = "MIT"
+rust-version = "1.85.1"
 edition = "2024"
 include = [
   "Cargo.toml",

--- a/src/finish.rs
+++ b/src/finish.rs
@@ -125,10 +125,10 @@ impl<T: Complete> AutoFinish<T> {
 }
 impl<T: Complete> Drop for AutoFinish<T> {
     fn drop(&mut self) {
-        if let Some(inner) = self.inner.take()
-            && let Err(e) = inner.complete()
-        {
-            panic!("{}", e);
+        if let Some(inner) = self.inner.take() {
+            if let Err(e) = inner.complete() {
+                panic!("{}", e);
+            }
         }
     }
 }


### PR DESCRIPTION
Hello there,

unfortunately I am in a bit of a bind. 

One of my projects is stuck on rust 1.86 for various reasons and
since you are probably aware your former dependency "core2" was yanked. This means my project no longer builds on systems where there is no Cargo.lock file. (so new systems). 

Your latest version fixes this but uses one feature from rust 1.87 in a single if statement.
The if statement is purely syntactical sugar as far as I can see.
As you can see in this PR the change is minimal.

I changed it to be compatible with rust 1.85.1
It would be greatly appreciated if you could merge this and make at least one release for these older versions
as the yank of core2 really screwed me over.

(Note: I do not use no-std, I am using your library with std::io)

Its up to you if you want to maintain this msrv going forward or increment it again, however for me at least one version that works with this older version of rust would be a lifesaver.

Sincerely
Alexander Schütz